### PR TITLE
Add OpenRouter support as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ pipeline:
   - type: generation
     method: llm
     parameters:
-      provider: openai
-      model: gpt-4o-mini
+      provider: openai  # You can also use 'openrouter' here
+      model: gpt-4o-mini  # For OpenRouter, use format like 'openai/gpt-3.5-turbo'
       template: |
         Ask a question regarding the sentence about the content.
         content: {chunk_faq}
@@ -90,7 +90,11 @@ output:
 2. Add a model provider:
 
 ```bash
+# For OpenAI
 synda provider add openai --api-key [YOUR_API_KEY]
+
+# For OpenRouter
+synda provider add openrouter --api-key [YOUR_OPENROUTER_API_KEY]
 ```
 
 3. Generate some synthetic data:
@@ -136,6 +140,7 @@ The following features are planned for future releases.
 - [x] Allow injecting params from distant step into prompt
 - [x] Add Ollama with structured generation output
 - [x] Retry a failed run
+- [x] Add OpenRouter support
 - [ ] Add asynchronous behaviour for any CLI
 - [ ] Add vLLM with structured generation output
 - [ ] Batch processing logic (via param.) for LLMs steps

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -1,0 +1,45 @@
+# Using OpenRouter with Synda
+
+Synda supports [OpenRouter](https://openrouter.ai/) as a provider for LLM generation steps. OpenRouter gives you access to a wide range of models from different providers through a single API.
+
+## Setup
+
+1. Sign up for an account at [OpenRouter](https://openrouter.ai/) and get your API key.
+
+2. Add OpenRouter as a provider in Synda:
+
+```bash
+synda provider add openrouter --api-key YOUR_OPENROUTER_API_KEY
+```
+
+## Usage in Configuration
+
+In your YAML configuration file, specify `openrouter` as the provider and use the appropriate model name:
+
+```yaml
+- type: generation
+  method: llm
+  parameters:
+    provider: openrouter
+    model: openai/gpt-3.5-turbo  # Format: provider/model-name
+    template: |
+      Your prompt template here
+    temperature: 0.7
+```
+
+## Available Models
+
+OpenRouter supports a wide range of models from different providers. The model name format is typically `provider/model-name`. Some examples include:
+
+- `openai/gpt-3.5-turbo`
+- `openai/gpt-4`
+- `anthropic/claude-2`
+- `anthropic/claude-instant-v1`
+- `google/palm-2-chat-bison`
+- `meta-llama/llama-2-70b-chat`
+
+For a complete and up-to-date list of available models, visit the [OpenRouter models page](https://openrouter.ai/models).
+
+## Example
+
+See the complete example configuration in the `examples/openrouter_example.yaml` file.

--- a/examples/openrouter_example.yaml
+++ b/examples/openrouter_example.yaml
@@ -1,0 +1,32 @@
+input:
+  type: csv
+  properties:
+    path: input.csv
+    target_column: content
+    separator: "\t"
+
+pipeline:
+  - type: split
+    method: chunk
+    name: chunk_faq
+    parameters:
+      size: 500
+
+  - type: generation
+    method: llm
+    parameters:
+      provider: openrouter
+      model: openai/gpt-3.5-turbo
+      template: |
+        Generate a concise summary of the following text.
+        
+        Text: {chunk_faq}
+        
+        Summary:
+      temperature: 0.7
+
+output:
+  type: csv
+  properties:
+    path: output.csv
+    separator: "\t"

--- a/synda/utils/llm_provider.py
+++ b/synda/utils/llm_provider.py
@@ -31,4 +31,6 @@ class LLMProvider:
     def _resolve_provider(provider: str):
         if provider == "ollama":
             return "ollama_chat"
+        elif provider == "openrouter":
+            return "openrouter"
         return provider

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from synda.utils.llm_provider import LLMProvider
+
+
+class TestLLMProvider(unittest.TestCase):
+    @patch("synda.utils.llm_provider.completion")
+    def test_openrouter_provider_resolution(self, mock_completion):
+        # Setup mock
+        mock_completion.return_value = {
+            "choices": [{"message": {"content": "Test response"}}]
+        }
+        
+        # Call the provider with openrouter
+        LLMProvider.call(
+            provider="openrouter",
+            model="openai/gpt-3.5-turbo",
+            api_key="test_key",
+            prompt="Test prompt",
+            temperature=0.7,
+        )
+        
+        # Check that the provider was correctly resolved
+        mock_completion.assert_called_once()
+        args, kwargs = mock_completion.call_args
+        
+        # Verify the model name was correctly formatted with the provider
+        self.assertEqual(kwargs["model"], "openrouter/openai/gpt-3.5-turbo")
+        
+        # Verify other parameters
+        self.assertEqual(kwargs["api_key"], "test_key")
+        self.assertEqual(kwargs["messages"][0]["content"], "Test prompt")
+        self.assertEqual(kwargs["temperature"], 0.7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR adds support for OpenRouter as a provider in Synda. OpenRouter gives access to a wide range of models from different providers through a single API.

## Changes

- Updated `_resolve_provider` method in `llm_provider.py` to handle OpenRouter
- Added documentation for OpenRouter integration in `docs/openrouter.md`
- Created an example configuration file in `examples/openrouter_example.yaml`
- Updated README.md to include OpenRouter instructions
- Added test case for OpenRouter provider resolution

## Testing

Added a unit test to verify that the OpenRouter provider is correctly resolved.